### PR TITLE
style: Font, hide goto-posts, rm GithubShareButton

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -29,7 +29,7 @@ import { PageHead } from './PageHead'
 import { PageAside } from './PageAside'
 import { Footer } from './Footer'
 import { NotionPageHeader } from './NotionPageHeader'
-import { GitHubShareButton } from './GitHubShareButton'
+// import { GitHubShareButton } from './GitHubShareButton'
 
 import styles from './styles.module.css'
 
@@ -286,7 +286,7 @@ export const NotionPage: React.FC<types.PageProps> = ({
         footer={footer}
       />
 
-      <GitHubShareButton />
+      {/* <GitHubShareButton /> */}
     </>
   )
 }

--- a/site.config.ts
+++ b/site.config.ts
@@ -58,7 +58,7 @@ export default siteConfig({
     },
     {
       title: 'Posts',
-      pageId: '5a186d4dc3d3497ebe6155b804bc6606'
+      pageId: 'fe7052915f0548809117516ff4a643a6'
     },
     // {
     //   title: 'Contact',

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -4,15 +4,14 @@
 
 
 /* hide about block */
-.notion-block-6928f842cce4404bb3572cc19de2b1f1 {
+a.notion-block-6928f842cce4404bb3572cc19de2b1f1 {
   display: none;
 }
 
 /* hide posts block */
-.notion-block-5a186d4dc3d3497ebe6155b804bc6606 {
+a.notion-block-fe7052915f0548809117516ff4a643a6 {
   display: none;
 }
-
 /* Pretty Scrollbar */
 ::-webkit-scrollbar {
   width: 20px;
@@ -33,7 +32,7 @@
   background-color: #a8bbbf;
 }
 
-/* ToC white-space get newline */
+/* ToC Layout, white-spacing */
 aside.notion-aside{
   padding-left: 5px;
   padding-right: 20px;

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,3 +1,5 @@
+@import url(//fonts.googleapis.com/earlyaccess/jejugothic.css);
+
 * {
   box-sizing: border-box;
 }
@@ -14,7 +16,7 @@ html {
 }
 
 body {
-  --notion-font: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+  --notion-font: 'Jeju Gothic', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
     'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
     'Droid Sans', 'Helvetica Neue', 'Noto Sans', sans-serif;
   font-family: var(--notion-font);

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -59,7 +59,7 @@
 }
 
 .notion-gallery-grid .notion-page-title-text {
-  font-size: 2em;
+  font-size: 1.5em;
   white-space: unset;
 }
 


### PR DESCRIPTION
목표 리스트
- 기본 폰트롤 제주고딕으로 global style 수정
- 갤러리 컬렉션 뷰에서 제목 폰트 사이즈 2em에서 1.5em으로 수정
- 우측 상단 Github 바로가기 버튼 주석처리